### PR TITLE
refactor: add none modifier to native types

### DIFF
--- a/src/GlobalHotKeys/NativeTypes.fs
+++ b/src/GlobalHotKeys/NativeTypes.fs
@@ -43,6 +43,7 @@ type WNDCLASSEX =
 
 [<Flags>]
 type Modifiers =
+  | None     = 0x0000
   | Alt      = 0x0001
   | Control  = 0x0002
   | NoRepeat = 0x4000


### PR DESCRIPTION
This simply allows hotkeys to be registered without a modifier

example: 
I can have a hotkey F1 without the required CTRL/ALT/.. modifiers by sending a 0 to the modifier flag.